### PR TITLE
[ENH] SH description (take 2)

### DIFF
--- a/src/05-derivatives/05-diffusion-derivatives.md
+++ b/src/05-derivatives/05-diffusion-derivatives.md
@@ -447,33 +447,51 @@ for instance, 3-vectors { 0.57735, 0.57735, 0.57735 } and
 { -0.57735, -0.57735, -0.57735 } are both permissible and equivalent to one
 another.
 
-#### Spherical Harmonics bases
+#### Spherical Harmonics
+
+- Concepts shared across all spherical harmonics bases:
+
+   -  Basis functions:
+
+      ![SH basis functions](https://latex.codecogs.com/gif.latex?Y_l^m(\theta,\phi)&space;=&space;\sqrt{\frac{(2l&plus;1)}{4\pi}\frac{(l-m)!}{(l&plus;m)!}}&space;P_l^m(\cos&space;\theta)&space;e^{im\phi}")
+
+      for integer *order* *l*, *phase* *m*, associated Legendre polynomials *P*.
+
+   -  (Truncated) basis coefficients:
+
+      ![SH basis coefficients](https://latex.codecogs.com/gif.latex?f(\theta,\phi)&space;=&space;\sum_{l=0}^{l_\text{max}}&space;\sum_{m=-l}^{l}&space;c_l^m&space;Y_l^m(\theta,\phi)")
+
+      for *maximum* spherical harmonic order *l<sub>max</sub>*.
 
 -  `MRtrix3`
-
-   -  Antipodally symmetric: all basis functions with odd degree are
-      assumed zero; `AntipodalSymmetry` MUST NOT be set to True.
 
    -  Functions assumed to be real: conjugate symmetry is assumed, i.e.
       *Y*(*l*,-*m*) = *Y*(*l*,*m*)\*, where \* denotes the complex
       conjugate.
 
-   -  Mapping of image volumes to spherical harmonic basis function
-      coefficients:
+   -  Antipodally symmetric: all basis functions with odd degree are
+      assumed zero; `AntipodalSymmetry` MUST NOT be set to `True`.
 
-      | **Volume** | **Coefficient**                   |
-      | ---------- | --------------------------------- |
-      | 0          | *l* = 0, *m* = 0                  |
-      | 1          | *l* = 2, *m* = 2 (imaginary part) |
-      | 2          | *l* = 2, *m* = 1 (imaginary part) |
-      | 3          | *l* = 2, *m* = 0                  |
-      | 4          | *l* = 2, *m* = 1 (real part)      |
-      | 5          | *l* = 2, *m* = 2 (real part)      |
-      | 6          | *l* = 4, *m* = 4 (imaginary part) |
-      | 7          | *l* = 4, *m* = 3 (imaginary part) |
-      | ...        | etc.                              |
+   -  Utilised basis functions:
 
-   -  Normalisation: ***TODO***
+      ![MRtrix3 SH basis functions](https://latex.codecogs.com/gif.latex?Y_{lm}(\theta,\phi)=\begin{Bmatrix}&space;0&\text{if&space;}l\text{&space;is&space;odd},\\&space;\sqrt{2}\times\text{Im}\left[Y_l^{-m}(\theta,\phi)\right]&\text{if&space;}m<0,\\&space;Y_l^0(\theta,\phi)&\text{if&space;}m=0,\\&space;\sqrt{2}\times\text{Re}\left[Y_l^m(\theta,\phi)\right]&\text{if&space;}m>0\\&space;\end{Bmatrix})
+
+   -  Mapping between image volume *V<sub>lm</sub>* and spherical harmonic basis
+      function coefficient *c<sub>lm</sub>*:
+
+      *V<sub>lm</sub>* = (*l*(*l*+1) / 2) + *m*
+
+      | ***V<sub>lm</sub>*** | ***c<sub>lm</sub>***              |
+      | -------------------- | --------------------------------- |
+      | 0                    | *l* = 0, *m* = 0                  |
+      | 1                    | *l* = 2, *m* = 2 (imaginary part) |
+      | 2                    | *l* = 2, *m* = 1 (imaginary part) |
+      | 3                    | *l* = 2, *m* = 0                  |
+      | 4                    | *l* = 2, *m* = 1 (real part)      |
+      | 5                    | *l* = 2, *m* = 2 (real part)      |
+      | 6                    | *l* = 4, *m* = 4 (imaginary part) |
+      | 7                    | *l* = 4, *m* = 3 (imaginary part) |
+      | ...                  | etc.                              |
 
    -  Relationship between maximal spherical harmonic degree *l<sub>max</sub>*
       and number of image volumes *N*:
@@ -493,7 +511,7 @@ another.
 
       | ***l<sub>max</sub>*** |  0  |  2  |  4  |  6  |  8  | ...  |
       | --------------------- | --: | --: | --: | --: | --: | :--: |
-      | ***N***               |   1 |   2 |  3  |  4  |  5  | etc. |
+      | ***N***               |  1  |  2  |  3  |  4  |  5  | etc. |
 
 -  `Descoteaux`
 

--- a/src/05-derivatives/05-diffusion-derivatives.md
+++ b/src/05-derivatives/05-diffusion-derivatives.md
@@ -476,28 +476,28 @@ another.
         conjugate.
 
     -   Antipodally symmetric: all basis functions with odd degree are
-        assumed zero; `AntipodalSymmetry` MUST NOT be set to `True`.
+        assumed zero; `AntipodalSymmetry` MUST NOT be set to `False`.
 
     -   Utilised basis functions:
 
         ![MRtrix3 SH basis functions](https://latex.codecogs.com/gif.latex?Y_{lm}(\theta,\phi)=\begin{Bmatrix}&space;0&\text{if&space;}l\text{&space;is&space;odd},\\&space;\sqrt{2}\times\text{Im}\left[Y_l^{-m}(\theta,\phi)\right]&\text{if&space;}m<0,\\&space;Y_l^0(\theta,\phi)&\text{if&space;}m=0,\\&space;\sqrt{2}\times\text{Re}\left[Y_l^m(\theta,\phi)\right]&\text{if&space;}m>0\\&space;\end{Bmatrix})
 
-    -   Mapping between image volume *V<sub>lm</sub>* and spherical harmonic basis
-        function coefficient *c<sub>lm</sub>*:
+    -   Mapping between image volume *V* and spherical harmonic basis
+        function coefficient *Y<sub>l,m</sub>*:
 
-        *V<sub>lm</sub>* = (*l*(*l*+1) / 2) + *m*
+        *V<sub>l,m</sub>* = (*l*(*l*+1) / 2) + *m*
 
-        | ***V<sub>lm</sub>*** | ***c<sub>lm</sub>***              |
-        | -------------------- | --------------------------------- |
-        | 0                    | *l* = 0, *m* = 0                  |
-        | 1                    | *l* = 2, *m* = 2 (imaginary part) |
-        | 2                    | *l* = 2, *m* = 1 (imaginary part) |
-        | 3                    | *l* = 2, *m* = 0                  |
-        | 4                    | *l* = 2, *m* = 1 (real part)      |
-        | 5                    | *l* = 2, *m* = 2 (real part)      |
-        | 6                    | *l* = 4, *m* = 4 (imaginary part) |
-        | 7                    | *l* = 4, *m* = 3 (imaginary part) |
-        | ...                  | etc.                              |
+        | ***V*** | **Coefficient**    |
+        | ------- | ------------------ |
+        | 0       | *Y<sub>0,0</sub>*  |
+        | 1       | *Y<sub>2,-2</sub>* |
+        | 2       | *Y<sub>2,-1</sub>* |
+        | 3       | *Y<sub>2,0</sub>*  |
+        | 4       | *Y<sub>2,1</sub>*  |
+        | 5       | *Y<sub>2,2</sub>*  |
+        | 6       | *Y<sub>4,-4</sub>* |
+        | 7       | *Y<sub>4,-3</sub>* |
+        | ...     | etc.               |
 
     -   Relationship between maximal spherical harmonic degree *l<sub>max</sub>*
         and number of image volumes *N*:

--- a/src/05-derivatives/05-diffusion-derivatives.md
+++ b/src/05-derivatives/05-diffusion-derivatives.md
@@ -340,7 +340,7 @@ Reserved keywords for models built into the specification are as follows:
 
     -   `ResponseFunctionTensor`: Vector of 4 floating-point values: three tensor eigenvalues, then reference *b*=0 intensity
 
-    -   `SphericalHarmonicBasis`: String. Options are: { `MRtrix3`, `Descoteaux` }. Details are provided in the [spherical harmonics bases](#spherical-harmonics-bases) section.
+    -   `SphericalHarmonicBasis`: String. Options are: { `MRtrix3` }. Details are provided in the [spherical harmonics bases](#spherical-harmonics-bases) section.
 
     -   `SphericalHarmonicDegree`: Integer. The maximal spherical harmonic order *l<sub>max</sub>*; the number of volumes in the associated NIfTI image must correspond to this value as per the relationship described in [spherical harmonics bases](#spherical-harmonics-bases) section.
 
@@ -444,7 +444,7 @@ in order to produce a [directionally-encoded colour](#data-dec),
 | `FillValue`                 | [Spherical coordinates](#data-spherical), [3-vectors](#data-3vector)                                                                                                                                              | OPTIONAL. Float; allowed values: { 0.0, NaN }. Value stored in image when number of discrete orientations in a voxel is fewer than the maximal number for that image.                                                                                     |
 | `OrientationRepresentation` | All except [scalar](#data-scalar)                                                                                                                                                                                 | REQUIRED. String; allowed values: { `dec`, `unitspherical`, `spherical`, `unit3vector`, `3vector`, `sh`, `amp`, `pdf`, `param` }. The [data representation](#data-representations) used to encode orientation information within the NIfTI image.         |
 | `ReferenceAxes`             | All except [scalar](#data-scalar)                                                                                                                                                                                 | REQUIRED. String; allowed values: { `ijk`, `xyz` }. Indicates whether the NIfTI image axes, or scanner-space axes, are used as reference axes for orientation information.                                                                                |
-| `SphericalHarmonicBasis`    | [Spherical harmonics](#data-sh)                                                                                                                                                                                   | REQUIRED. String; allowed values: { `MRtrix3`, `Descoteaux` }. Basis by which to define the interpretation of image values across volumes as spherical harmonics coefficients.                                                                            |
+| `SphericalHarmonicBasis`    | [Spherical harmonics](#data-sh)                                                                                                                                                                                   | REQUIRED. String; allowed values: { `MRtrix3` }. Basis by which to define the interpretation of image values across volumes as spherical harmonics coefficients.                                                                                          |
 | `SphericalHarmonicDegree`   | [Spherical harmonics](#data-sh)                                                                                                                                                                                   | REQUIRED. Integer. Maximal degree of the spherical harmonic basis employed.                                                                                                                                                                               |
 
 If `AntipodalSymmetry` is True, then no constraints are imposed with respect
@@ -518,10 +518,6 @@ another.
         | ***l<sub>max</sub>*** | 0 | 2 | 4 | 6 | 8 | ...  |
         | --------------------- |--:|--:|--:|--:|--:| :--: |
         | ***N***               | 1 | 2 | 3 | 4 | 5 | etc. |
-
--   `Descoteaux`
-
-    ***TODO***
 
 ## Demonstrative examples
 


### PR DESCRIPTION
Manually took the changes in #8 and applied them to the current state of the BEP.

I expect that when details of the `Descoteaux` SH convention are introduced, some of the details that are currently attributed to the `MRtrix3` convention will be shared between the two, and will therefore be moved to the "concepts shared across all spherical harmonics bases" section.