### PR TITLE
Major refactoring for upstream changes / blocks

### DIFF
--- a/src/derivatives/05-diffusion-derivatives.md
+++ b/src/derivatives/05-diffusion-derivatives.md
@@ -346,6 +346,7 @@ Dictionary `"ResponseFunction"` has the following reserved keywords:
     Dimensions of NIfTI image "`sub-01_model-tensor_param-fa_dwimap.nii.gz`": *I*x*J*x*K* ([scalar](#encoding-scalar))
 
     Contents of file `sub-01_model-tensor_param-diffusivity_dwimap.json`:
+
     ```JSON
     {
         "Description": "Diffusion Coefficient, encoded as a tensor representation",
@@ -368,6 +369,7 @@ Dictionary `"ResponseFunction"` has the following reserved keywords:
     ```
 
     Contents of file `sub-01_model-tensor_param-s0_dwimap.json`:
+
     ```JSON
     {
         "Description": "Estimated signal intensity with no diffusion weighting, ie. S0",
@@ -382,6 +384,7 @@ Dictionary `"ResponseFunction"` has the following reserved keywords:
     ```
 
     Contents of file `sub-01_model-tensor_param-fa_dwimap.json`:
+
     ```JSON
     {
         "Description": "Fractional Anisotropy",
@@ -500,7 +503,7 @@ Dictionary `"ResponseFunction"` has the following reserved keywords:
             "Type": "sh"
         },
         "ResponseFunction": {
-            "Coefficients": [ [ 544.90770181 ],
+            "Coefficients": [ [ 3544.90770181 ],
                               [ 134.441453035 ],
                               [ 32.0826839826 ],
                               [ 29.3674604452 ] ],
@@ -636,6 +639,7 @@ Dictionary `"ResponseFunction"` has the following reserved keywords:
             "Type": "unit3vector"
         }
     }
+    ```
 
     Contents of JSON file "`sub-01_model-bs_desc-mean_param-vf_dwimap.json`":
 
@@ -659,6 +663,7 @@ Dictionary `"ResponseFunction"` has the following reserved keywords:
             "Type": "scalar"
         }
     }
+    ```
 
     Contents of JSON file "`sub-01_model-bs_desc-mean_param-vfsum_dwimap.json`":
 
@@ -679,6 +684,7 @@ Dictionary `"ResponseFunction"` has the following reserved keywords:
             }
         }
     }
+    ```
 
     Contents of JSON file "`sub-01_model-bs_desc-mean_param-diffusivity_dwimap.json`":
 
@@ -700,6 +706,7 @@ Dictionary `"ResponseFunction"` has the following reserved keywords:
         },
         "Units": "mm^2/s"
     }
+    ```
 
     Contents of JSON file "`sub-01_model-bs_desc-mean_param-dstd_dwimap.json`":
 

--- a/src/derivatives/05-diffusion-derivatives.md
+++ b/src/derivatives/05-diffusion-derivatives.md
@@ -129,7 +129,7 @@ see [parameter metadata](#parameter-metadata).
         and reference frame for angles:
 
         1.  Distance from origin,
-            encoding some parameter of interest.
+            encoding some non-negative parameter of interest.
 
         1.  Inclination / polar angle in radians,
             relative to the zenith direction being the positive direction of the *third* reference axis
@@ -163,9 +163,8 @@ see [parameter metadata](#parameter-metadata).
 
     1.  Value per orientation
 
-        The *norm* of the 3-vector encodes some parameter of interest,
+        The *norm* of the 3-vector encodes some non-negative parameter of interest,
         while its normalized form encodes an orientation on the unit sphere.
-        Note that only non-negative parameters may be encoded in this form.
 
     1.  Orientations only
 
@@ -279,13 +278,13 @@ Dictionary `"Model["Parameters"]"` has the following reserved keywords that may 
 The following table defines reserved fields relevant to individual model parameters.
 Some fields are applicable only to specific [orientation encoding types](#orientation-encoding-types).
 
-| **Key name**        | Relevant [orientation encoding types](#orientation-encoding-types)                              | **Description**                                                                                                                                                                                                                       |
-| ------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| BootstrapAxis       | Any                                                                                             | OPTIONAL. Integer. If multiple realisations of a given parameter are stored in a NIfTI image, this field nominates the image axis (indexed from zero) along which those multiple realisations are stored.                             |
-| Description         | Any                                                                                             | OPTIONAL. String. Text description of what model parameter is encoded in the corresponding data file.                                                                                                                                 |
-| NonNegativity       | All except [spherical coordinates](#encoding-spherical) and [unit 3-vectors](#encoding-3vector) | OPTIONAL. String. Options are: { `regularized`, `constrained` }. Specifies whether, during model fitting, the parameter was regularised to not take extreme negative values, or was explicitly forbidden from taking negative values. |
-| OrientationEncoding | Any                                                                                             | REQUIRED if dimensionality of NIfTI image is greater than three. Dictionary. Provides information requisite to the interpretation of orientation information encoded in each voxel; more details below.                               |
-| ResponseFunction    | [Spherical harmonics](#encoding-sh)                                                             | OPTIONAL. Dictionary. Specifies a response function that was utilised by a deconvolution algorithm; more details below.                                                                                                               |
+| **Key name**        | Relevant [orientation encoding types](#orientation-encoding-types)                         | **Description**                                                                                                                                                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BootstrapAxis       | Any                                                                                        | OPTIONAL. Integer. If multiple realisations of a given parameter are stored in a NIfTI image, this field nominates the image axis (indexed from zero) along which those multiple realisations are stored.                             |
+| Description         | Any                                                                                        | OPTIONAL. String. Text description of what model parameter is encoded in the corresponding data file.                                                                                                                                 |
+| NonNegativity       | All except [spherical coordinates](#encoding-spherical) and [3-vectors](#encoding-3vector) | OPTIONAL. String. Options are: { `regularized`, `constrained` }. Specifies whether, during model fitting, the parameter was regularised to not take extreme negative values, or was explicitly forbidden from taking negative values. |
+| OrientationEncoding | Any                                                                                        | REQUIRED if dimensionality of NIfTI image is greater than three. Dictionary. Provides information requisite to the interpretation of orientation information encoded in each voxel; more details below.                               |
+| ResponseFunction    | [Spherical harmonics](#encoding-sh)                                                        | OPTIONAL. Dictionary. Specifies a response function that was utilised by a deconvolution algorithm; more details below.                                                                                                               |
 
 Dictionary `"OrientationEncoding"` has the following reserved keywords:
 

--- a/src/derivatives/05-diffusion-derivatives.md
+++ b/src/derivatives/05-diffusion-derivatives.md
@@ -95,7 +95,7 @@ entity "`_param-<label>`" MUST NOT be included; e.g.:
 
 There are many mathematical bases that may be used
 in the encoding of parameters that vary as a function of orientation.
-A list of such functions supported by the specification is enuerated below,
+A list of such functions supported by the specification is enumerated below,
 accompanied by requisite information specific to each representation.
 
 For image data that encode orientation information,
@@ -169,7 +169,7 @@ see [parameter metadata](#parameter-metadata).
     1.  Orientations only
 
         Each triplet of values encodes an orientation on the unit sphere
-        (i.e. the vector norm MUST be 1.0);
+        (that is, the vector norm MUST be 1.0);
         no quantitative value is associated with each orientation.
 
     Number of image volumes is equal to (3x*N*),
@@ -216,7 +216,7 @@ see [parameter metadata](#parameter-metadata).
 
 For some models,
 it is common to export not only the best fit of the model to the empirical data,
-but multiple reaslisations of that fit taking into account image noise,
+but multiple realizations of that fit taking into account image noise,
 typically through some form of bootstrapping procedure.
 Where this occurs,
 the image data for each parameter possess an additional dimension,


### PR DESCRIPTION
Replaces #90.

Resolving the BEP against the absence of both complex inheritance and suffix distinction is not as simple as removing complex inheritance and swapping suffices; attempting to do so just breaks everything around it. But given prior precedent I'm pessimistic about my ability to convey this convincingly. So I'm better off making the changes necessary to conform to the main structural constraints (no IP changes, single fixed suffix) that will both retain compatibility with extension beyond the most trivial of diffusion models, and hopefully not be objectionable on other bases.

I've ended up making a much broader scope of changes than just "doing #90 differently", as there are too many moving parts to handle in isolation. I'll try to break up my description here in terms of aspects that address those core structural constraints, vs. other things that to greater or lesser necessity got changed along the way. I can't finish this off right now as I have other urgent tasks, but hopefully this is enough to elicit opinions.

## Primary structure

-   One sidecar file per model parameter data file; no advanced inheritance principle required (and no smuggling in complex inheritance by other means).
-   Distinguish between "model metadata" and "parameter metadata".
    (Serves similar purpose to the former MFP / MDP distinction, but applies exclusively in the context of metadata, not image data)
-   Duplicate model metadata across all sidecars.
-   Use metadata sub-dictionary to separate metadata applicable to a model as a whole from metadata applicable to specific parameters.

## Other changes

-   More extensive use of metadata sub-dictionaries.
    In particular, those metadata fields specific to the interpretation of data across a NIfTI image axis as encoding some anisotropic information have been collated into their own sub-dictionary.
-   More explicit about image axes used for orientation encoding vs. bootstrapping
    Having to try to make the `bedpostx` example more mature, and thinking about future orientation encoding types, I deemed it necessary to be explicit about which image axes encode orientation information vs. different bootstrap realisations of a model. There are some images that have orientation information but no bootstrapping, some that have bootstrap realisations but no orientation information. Then, in the future, there are orientation encoding types that will require multiple image axes (I'm thinking SHARD and DSI PDFs). So I'm not convinced that saying "bootstrapping comes after orientation stuff" is adequate, and would prefer to be explicit about both.
-   Removal of fields about which gradients / shells were utilised in the model fit (#48).
    I don't think it makes sense to specify which volumes / shells were utilised, but not what image data were used, especially when the former was already incomplete. I tried adding the latter, but it started to look an awful lot like provenance.
-   Replace "data representations" / "orientation representation" with "orientation encoding" (#91).
-   Non-negativity is not a constraint of a model as a whole; it is a constraint that may be applied to individual parameters of that model. Therefore I've stored it on an individual parameter basis, rather than being a single field applicable to the model as a whole.
-   Removed reserved labels of models and parameters.
    I think these do more harm than good; it makes the whole ecosystem inflexible, might be misinterpreted as not supporting anything outside of that scope, and runs into a weird situation where the corresponding entities are neither arbitrary labels nor define a finite restricted set of options. If the demonstrative examples are moved out of the document, then their scope could be increased to exemplify some of these.
    The counter to this would be that by controlling the entity labels, specific parametric maps generated by one pipeline would be possible to robustly identify by another. While I'm myself interested in this, I'm not sure that partial control of entity labels solves that problem without consequence. Elsewhere there's discouragement of placing too much automated interpretation on entity labels (eg. `_dir-` to discover phase encoding information). And for such abbreviated labels, hard to dictate that a dataset would be non-conformant if some App / user were to store an image with a two-character label that encodes a parameter other than the one that the specification attributes to that two-character label.

## Outstanding questions

-   For FSL `bedpostx` orientations when stored in spherical coordinates:
    -   Is the interpretation of polar angles conformant with the ISO specification here, or is a transformation required?
    -   Are they truly defined with respect to the image axes, or do they conform to the same convention as `bvecs`, which has a flip along the first axis in the case of a positive determinant?
-   For spherical deconvolution with multiple kernels, should metadata encoding the response functions be defined only with respect to the parameter corresponding to each, or should all response functions be defined within the scope of model metadata?
-   Demonstrative examples section becomes even longer when you've got metadata duplicated across each JSON contents. It's now more than half the document. I would prefer to defer this entirely to an external repository where exemplar data are explicitly stored. This would also better facilitate demonstrating scenarios where there are multiple possible solutions; eg. `bedpostx` concatenating all stick orientations / volume fractions into images versus having each parameter for each stick stored as its own image.
-   For metadata, possible that software implementation / model description / description of individual encoded parameter could all have their own URLs.
